### PR TITLE
Set Jest test environment to jsdom for browser APIs like HTMLElement

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+// Set jest test environment to jsdom for browser API's like HTMLElement
+module.exports = {
+	testEnvironment: 'jsdom',
+};


### PR DESCRIPTION
Resolves #84 


### **Tasks completed:**
- Enable jsdom for Jest to Support Browser APIs
- Set the Jest test environment to  `jsdom` to allow tests involving browser-specific APIs (e.g., HTMLElement, document, window) to run correctly. This resolves the `ReferenceError: HTMLElement is not defined error in recipeCard.test.js`

---
- DOM-based unit tests now run in a simulated browser environment.
