### PR TITLE
Refactor JSDoc Config & CI Workflow to Remove Redundancy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,6 @@ jobs:
         run: npm run htmlhint || touch htmlhint.failed
         continue-on-error: true
 
-      - name: Generate JSDoc
-        run: npm run jsdoc
-
       - name: Fail job if any linter failed
         run: |
           if [ -f eslint.failed ] || [ -f stylelint.failed ] || [ -f htmlhint.failed ]; then

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -8,7 +8,6 @@
   "opts": {
     "destination": "./docs",
     "recurse": true,
-    "readme": "./README.md",
     "template": "templates/default"
   },
   "plugins": []


### PR DESCRIPTION
## Description  
- **jsdoc.json**  
  - Removed the `readme` entry from `opts`—we’ll rely on the default project README.  
- **GitHub Actions**  
  - Deleted the extra “Generate JSDoc” step in the **lint** job.  
  - Ensured JSDoc now runs **only** in the dedicated **document** job.  
  - Kept linting, testing, and docs generation seperate
  
- **Testing**  
  - Deleted all existing files under `/docs`.  
  - Ran `npm run jsdoc` locally to regenerate from scratch—everything was recreated and JSDoc exited with no errors.


- [x] CI passes with lint, test, and single JSDoc generation.  
- [x] Local regeneration of `/docs` from scratch completes without errors.  

Please review and merge!  
